### PR TITLE
tee_storage: Fix return value of TEE_GetObjectInfo1

### DIFF
--- a/internal_api/storage/tee_storage_api.c
+++ b/internal_api/storage/tee_storage_api.c
@@ -84,6 +84,7 @@ TEE_Result TEE_GetObjectInfo1(TEE_ObjectHandle object,
 	if (object->objectInfo.objectType !=
 	    TEE_TYPE_DATA && object->objectInfo.handleFlags & TEE_HANDLE_FLAG_INITIALIZED) {
 		objectInfo->keySize = BYTE2BITS(object->key->key_lenght);
+		ret = TEE_SUCCESS;
 	} else {
 		objectInfo->keySize = 0;
 	}


### PR DESCRIPTION
TEE_GetObjectInfo1 for object type other than TEE_TYPE_DATA
with keySize can return TEE_SUCCESS. Added the same

Signed-off-by: Harish Jenny K N <harish_kandiga@mentor.com>
Change-Id: I76b782ff2d735cfd08e8b038ae15c15e000d091e